### PR TITLE
Extends the parser interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,6 +242,16 @@ export interface Style {
  */
 export interface StyleParser {
   /**
+   * Constructor interface
+   */
+  new(): StyleParser;
+
+  /**
+   * The name of the Parser instance
+   */
+  name: string;
+
+  /**
    * Parses the inputStyle and transforms it to the GeoStyler Style
    *
    * @param inputStyle
@@ -255,4 +265,65 @@ export interface StyleParser {
    * @param geoStylerStyle Style
    */
   writeStyle(geoStylerStyle: Style): Promise<any>;
+
+  /**
+   * Parses an input Rule and transforms it to a GeoStyler Rule
+   *
+   * @param inputRule
+   */
+  readRule?(inputRule: any): Promise<Rule>;
+
+  /**
+   * Reads a GeoStyler Rule and transforms it to a target Rule
+   * representation.
+   *
+   * @param geoStylerRule Rule
+   */
+  writeRule?(geoStylerRule: Rule): Promise<any>;
+
+  /**
+   * Parses an input Filter and transforms it to a GeoStyler Filter
+   *
+   * @param inputFilter
+   */
+  readFilter?(inputFilter: any): Promise<Filter>;
+
+  /**
+   * Reads a GeoStyler Filter and transforms it to a target Filter
+   * representation.
+   *
+   * @param geoStylerFilter Filter
+   */
+  writeFilter?(geoStylerFilter: Filter): Promise<any>;
+
+  /**
+   * Parses an input ScaleDenominator and transforms it to a GeoStyler
+   * ScaleDenominator
+   *
+   * @param inputScaleDenominator
+   */
+  readScaleDenominator?(inputScaleDenominator: any): Promise<ScaleDenominator>;
+
+  /**
+   * Reads a GeoStyler ScaleDenominator and transforms it to a target
+   * ScaleDenominator representation
+   *
+   * @param geoStylerScaleDenominator ScaleDenominator
+   */
+  writeScaleDenominator?(geoStylerScaleDenominator: ScaleDenominator): Promise<any>;
+
+  /**
+   * Parses an input Symbolizer and transforms it to a GeoStyler Symbolizer
+   *
+   * @param inputSymbolizer
+   */
+  readSymbolizer?(inputSymbolizer: any): Promise<Symbolizer>;
+
+  /**
+   * Reads a GeoStyler Symbolizer and transforms it to a target Symbolizer
+   * representation
+   *
+   * @param geoStylerSymbolizer Symbolizer
+   */
+  writeSymbolizer?(geoStylerSymbolizer: Symbolizer): Promise<any>;
 }


### PR DESCRIPTION
This adds some needed props and methods to the `StyleParser` interface:

- `new`: This is needed to allow the construction of this interface. E.g:
```typescript
const myParsers: StyleParser[] = [
  SldStyleParser,
  OpenlayersStyleParser,
  …
];
const parserInstance = new myParsers[0]();
parserInstance.readStyle(sldStyle);
…
```
- `name`: The name for the parser. Useful for the visual representation of a parser. https://github.com/terrestris/geostyler/issues/111

- `read…` and `write…` methods for subinstances of the `Style` as proposed here: https://github.com/terrestris/geostyler/issues/97
The methods are optional as they might be very useful but not necessary for the parser.
