### PR TITLE
Introduces constructable interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,11 +242,6 @@ export interface Style {
  */
 export interface StyleParser {
   /**
-   * Constructor interface
-   */
-  new(): StyleParser;
-
-  /**
    * The name of the Parser instance
    */
   name: string;
@@ -326,4 +321,11 @@ export interface StyleParser {
    * @param geoStylerSymbolizer Symbolizer
    */
   writeSymbolizer?(geoStylerSymbolizer: Symbolizer): Promise<any>;
+}
+
+export interface StyleParserConstructable extends StyleParser {
+  /**
+   * Constructor interface
+   */
+  new(): StyleParser;
 }


### PR DESCRIPTION
This introduces the `StyleParserConstructable` and moves the constructor interface into it.
The reason is that extending the `StyleParser` with included constructor interface was impossible.

To instantiate an unknown type of a `StyleParser` it is know needed to use the `StyleParserConstructable` instead of the `StyleParser`. Everything else will work as before.

Compare: https://stackoverflow.com/a/13408029