### PR TITLE
Refactors name to title

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,11 +242,6 @@ export interface Style {
  */
 export interface StyleParser {
   /**
-   * The name of the Parser instance
-   */
-  name: string;
-
-  /**
    * Parses the inputStyle and transforms it to the GeoStyler Style
    *
    * @param inputStyle
@@ -328,4 +323,8 @@ export interface StyleParserConstructable extends StyleParser {
    * Constructor interface
    */
   new(): StyleParser;
+  /**
+   * The name of the Parser instance
+   */
+  title: string;
 }


### PR DESCRIPTION
This refactors the `name` property of the `StyleParser` for two reasons.
1. The name should definetly be static. But as you can't model static properties on an interface in TypeScript, we set it on the `StyleParserConstructable`.
2. As the `name` property allready exists on `[function].constructor` we rename it to `title`.