### PR TITLE
Extend LineSymbolizer Definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -203,6 +203,7 @@ export interface LineSymbolizer extends BaseSymbolizer {
   join?: 'bevel' | 'round' | 'miter';
   miterLimit?: number;
   offset?: number;
+  perpendicularOffset?: number;
   pattern?: string;
   roundLimit?: number;
   type?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -202,8 +202,10 @@ export interface LineSymbolizer extends BaseSymbolizer {
   gradient?: any[];
   join?: 'bevel' | 'round' | 'miter';
   miterLimit?: number;
+  // TODO check if offset is being used somewhere, or if perpendicularOffset and dashOffset already replace it
   offset?: number;
   perpendicularOffset?: number;
+  dashOffset?: number;
   pattern?: string;
   roundLimit?: number;
   type?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -200,6 +200,7 @@ export interface LineSymbolizer extends BaseSymbolizer {
   dasharray?: number[];
   gapWidth?: number;
   gradient?: any[];
+  graphicStroke?: PointSymbolizer; 
   join?: 'bevel' | 'round' | 'miter';
   miterLimit?: number;
   // TODO check if offset is being used somewhere, or if perpendicularOffset and dashOffset already replace it


### PR DESCRIPTION
Add definitions for `perpendicularOffset`, `dashOffset` and `graphicStroke`. 

With `perpendicularOffset` the offset of a line can be described.
With `lineDashOffset` the offset of a dasharray can be defined (shift start of dasharray).
With `graphicStroke` Symbols and WellKnownNames can be used to describe the style of a line.