### PR TITLE
Set URL for jsdom environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "transform": {
       "\\.(ts)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testRegex": "/.*\\.spec.(ts|js)$"
+    "testRegex": "/.*\\.spec.(ts|js)$",
+    "testURL": "http://localhost/"
   },
   "devDependencies": {
     "np": "3.0.4"


### PR DESCRIPTION
This PR sets the testURL in jest config, otherwise the test suite fails with following error

Test suite failed to run

SecurityError: localStorage is not available for opaque origins
See also here facebook/jest#6766 (comment)