### PR TITLE
Multiple symbolizers in one rule

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,14 +14,9 @@ export interface ScaleDenominator {
 }
 
 /**
- * The type of the Style for basic Styles.
- */
-export type BasicStyleType = 'Point' | 'Fill' | 'Line';
-
-/**
  * The type of the Style.
  */
-export type StyleType = BasicStyleType[];
+export type StyleType = 'Point' | 'Fill' | 'Line';
 
 /**
  * The possible Operator used for comparison Filters.
@@ -245,7 +240,6 @@ export interface Rule {
 export interface Style {
   name: string;
   rules: Rule[];
-  type: StyleType;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,9 +14,14 @@ export interface ScaleDenominator {
 }
 
 /**
+ * The type of the Style for basic Styles.
+ */
+export type BasicStyleType = 'Point' | 'Fill' | 'Line';
+
+/**
  * The type of the Style.
  */
-export type StyleType = 'Point' | 'Fill' | 'Line';
+export type StyleType = BasicStyleType[];
 
 /**
  * The possible Operator used for comparison Filters.
@@ -231,7 +236,7 @@ export interface Rule {
   name: string;
   filter?: Filter;
   scaleDenominator?: ScaleDenominator;
-  symbolizer: Symbolizer;
+  symbolizer: Symbolizer[];
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@types/node": "10.5.7",
     "@types/jest": "23.3.1",
-    "jest": "23.1.0",
+    "jest": "23.4.2",
     "ts-jest": "23.0.0",
     "tslint": "5.10.0",
     "typescript": "2.9.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@types/node": "10.5.7",
     "@types/jest": "23.3.1",
-    "jest": "23.4.2",
+    "jest": "23.1.0",
     "ts-jest": "23.0.0",
     "tslint": "5.10.0",
     "typescript": "2.9.1"

--- a/sample.ts
+++ b/sample.ts
@@ -2,7 +2,6 @@ import { Style } from 'index';
 
 const sampleStyle: Style = {
   name: 'Sample Point Style',
-  type: 'Point',
   rules: [
     {
       name: 'Young Peter',
@@ -14,7 +13,7 @@ const sampleStyle: Style = {
         min: 500,
         max: 1000
       },
-      symbolizer: {
+      symbolizer: [{
         kind: 'Icon',
         visibility: false,
         allowOverlap: true,
@@ -22,7 +21,7 @@ const sampleStyle: Style = {
         optional: false,
         rotationAlignment: 'map',
         spacing: 21
-      }
+      }]
     },
     {
       name: 'Twelve year old Peter',
@@ -34,7 +33,7 @@ const sampleStyle: Style = {
         min: 500,
         max: 1000
       },
-      symbolizer: {
+      symbolizer: [{
         kind: 'Text',
         visibility: false,
         allowOverlap: true,
@@ -45,7 +44,7 @@ const sampleStyle: Style = {
         spacing: 21,
         haloColor: '#ff00aa',
         haloWidth: 4
-      }
+      }]
     },
     {
       name: 'Old Peter',
@@ -57,12 +56,12 @@ const sampleStyle: Style = {
         min: 500,
         max: 1000
       },
-      symbolizer: {
+      symbolizer: [{
         kind: 'Circle',
         visibility: false,
         radius: 5,
         spacing: 21
-      }
+      }]
     }
   ]
 };


### PR DESCRIPTION
# Breaking change

Added definition for allowing multiple symbolizers within a single rule. This follows the SLD specification, where 0..N symbolizers are allowed. 

sample.ts was updated accordingly.

**Important:** Due to updating the definition of symbolizer from `symbolizer: Symbolizer` to `symbolizer: Symbolizer[]`, as well as removing `type: StyleType` from `interface Style`this is a breaking change.