### PR TITLE
Definitions for WellKnownNames

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ export interface NegationFilter extends Filter  {
 /**
  * The kind of the Symbolizer
  */
-export type SymbolizerKind = 'Circle' | 'Fill' | 'Icon' | 'Line' |'Text'
+export type SymbolizerKind = 'Fill' | 'Icon' | 'Line' | 'Text' | 'Mark' 
 
 /**
  * A Symbolizer describes the style representation of geographical data.
@@ -109,18 +109,90 @@ export interface BasePointSymbolizer extends BaseSymbolizer {
 }
 
 /**
+ * MarkSymbolizer describes the style representation of POINT data, if styled as with
+ * a regular geometry.
+ */
+export type MarkSymbolizer = CircleSymbolizer | SquareSymbolizer | TriangleSymbolizer | StarSymbolizer | CrossSymbolizer | XSymbolizer;
+
+/**
+ * A BaseMarkSymbolizer describes the base style representation of POINT data if styled with
+ * a regular geometry.
+ */
+export interface BaseMarkSymbolizer extends BasePointSymbolizer {
+  kind: 'Mark';
+  wellKnownName: 'Circle' | 'Square' | 'Triangle' | 'Star' | 'Cross' | 'X';
+  points?: number;
+  strokeColor?: string;
+  strokeOpacity?: number;
+  strokeWidth?: number;
+  angle?: number;
+  rotation?: number;
+}
+
+/**
  * A CircleSymbolizer describes the style representation of POINT data if styled with
  * a regular circle geometry.
  */
-export interface CircleSymbolizer extends BasePointSymbolizer {
-  kind: 'Circle';
+export interface CircleSymbolizer extends BaseMarkSymbolizer {
+  wellKnownName: 'Circle';
   blur?: number;
   pitchAlignment?: 'map' | 'viewport';
   pitchScale?: 'map' | 'viewport';
   radius?: number;
-  strokeColor?: string;
-  strokeOpacity?: number;
-  strokeWidth?: number;
+}
+
+/**
+ * A SquareSymbolizer describes the style representation of POINT data if styled with
+ * a square geometry.
+ */
+export interface SquareSymbolizer extends BaseMarkSymbolizer {
+  wellKnownName: 'Square';
+  points: 4;
+  radius?: number;
+}
+
+/**
+ * A TriangleSymbolizer describes the style representation of POINT data if styled with
+ * a regular triangle geometry.
+ */
+export interface TriangleSymbolizer extends BaseMarkSymbolizer {
+  wellKnownName: 'Triangle';
+  points: 3;
+  radius?: number;
+}
+
+/**
+ * A StarSymbolizer describes the style representation of POINT data if styled with
+ * a regular star geometry.
+ */
+export interface StarSymbolizer extends BaseMarkSymbolizer {
+  wellKnownName: 'Star';
+  points: 5;
+  radius1?: number;
+  radius2?: number;
+}
+
+/**
+ * A CrossSymbolizer describes the style representation of POINT data if styled with
+ * a regular cross geometry
+ */
+export interface CrossSymbolizer extends BaseMarkSymbolizer {
+  wellKnownName: 'Cross';
+  points: 4;
+  radius1?: number;
+  radius2: 0;
+}
+
+/**
+ * A CrossSymbolizer describes the style representation of POINT data if styled with
+ * a regular cross geometry
+ */
+export interface XSymbolizer extends BaseMarkSymbolizer {
+  wellKnownName: 'X';
+  points: 4;
+  radius1?: number;
+  radius2: 0;
+  angle: number;
 }
 
 /**
@@ -216,7 +288,7 @@ export interface LineSymbolizer extends BaseSymbolizer {
 /**
  * Operators used for Point symbolization.
  */
-export type PointSymbolizer = IconSymbolizer | CircleSymbolizer | TextSymbolizer
+export type PointSymbolizer = IconSymbolizer | MarkSymbolizer | TextSymbolizer
 
 /**
  * All operators.

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,17 +21,17 @@ export type StyleType = 'Point' | 'Fill' | 'Line';
 /**
  * The possible Operator used for comparison Filters.
  */
-export type ComparisonOperator = '==' | '*=' | '!=' | '<' | '<=' | '>' | '>='
+export type ComparisonOperator = '==' | '*=' | '!=' | '<' | '<=' | '>' | '>=';
 
 /**
  * The possible Operator used for combination Filters.
  */
-export type CombinationOperator = '&&' | '||'
+export type CombinationOperator = '&&' | '||';
 
 /**
  * The Operator used for negation Filters.
  */
-export type NegationOpertaor = '!'
+export type NegationOpertaor = '!';
 
 /**
  * All operators.
@@ -86,7 +86,7 @@ export interface NegationFilter extends Filter  {
 /**
  * The kind of the Symbolizer
  */
-export type SymbolizerKind = 'Fill' | 'Icon' | 'Line' | 'Text' | 'Mark' 
+export type SymbolizerKind = 'Fill' | 'Icon' | 'Line' | 'Text' | 'Mark';
 
 /**
  * A Symbolizer describes the style representation of geographical data.
@@ -289,12 +289,12 @@ export interface LineSymbolizer extends BaseSymbolizer {
 /**
  * Operators used for Point symbolization.
  */
-export type PointSymbolizer = IconSymbolizer | MarkSymbolizer | TextSymbolizer
+export type PointSymbolizer = IconSymbolizer | MarkSymbolizer | TextSymbolizer;
 
 /**
  * All operators.
  */
-export type Symbolizer = PointSymbolizer | LineSymbolizer | FillSymbolizer
+export type Symbolizer = PointSymbolizer | LineSymbolizer | FillSymbolizer;
 
 /**
  * A Rule combines a specific amount of data (defined by a filter and a

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,12 +115,17 @@ export interface BasePointSymbolizer extends BaseSymbolizer {
 export type MarkSymbolizer = CircleSymbolizer | SquareSymbolizer | TriangleSymbolizer | StarSymbolizer | CrossSymbolizer | XSymbolizer;
 
 /**
+ * Supported WellKnownNames
+ */
+export type WellKnownName = 'Circle' | 'Square' | 'Triangle' | 'Star' | 'Cross' | 'X';
+
+/**
  * A BaseMarkSymbolizer describes the base style representation of POINT data if styled with
  * a regular geometry.
  */
 export interface BaseMarkSymbolizer extends BasePointSymbolizer {
   kind: 'Mark';
-  wellKnownName: 'Circle' | 'Square' | 'Triangle' | 'Star' | 'Cross' | 'X';
+  wellKnownName: WellKnownName;
   angle?: number;
   points?: number;
   radius?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,12 +121,12 @@ export type MarkSymbolizer = CircleSymbolizer | SquareSymbolizer | TriangleSymbo
 export interface BaseMarkSymbolizer extends BasePointSymbolizer {
   kind: 'Mark';
   wellKnownName: 'Circle' | 'Square' | 'Triangle' | 'Star' | 'Cross' | 'X';
+  angle?: number;
   points?: number;
+  rotation?: number;
   strokeColor?: string;
   strokeOpacity?: number;
   strokeWidth?: number;
-  angle?: number;
-  rotation?: number;
 }
 
 /**
@@ -146,8 +146,9 @@ export interface CircleSymbolizer extends BaseMarkSymbolizer {
  * a square geometry.
  */
 export interface SquareSymbolizer extends BaseMarkSymbolizer {
-  wellKnownName: 'Square';
+  angle: 45;
   points: 4;
+  wellKnownName: 'Square';
   radius?: number;
 }
 
@@ -156,8 +157,8 @@ export interface SquareSymbolizer extends BaseMarkSymbolizer {
  * a regular triangle geometry.
  */
 export interface TriangleSymbolizer extends BaseMarkSymbolizer {
-  wellKnownName: 'Triangle';
   points: 3;
+  wellKnownName: 'Triangle';
   radius?: number;
 }
 
@@ -166,8 +167,8 @@ export interface TriangleSymbolizer extends BaseMarkSymbolizer {
  * a regular star geometry.
  */
 export interface StarSymbolizer extends BaseMarkSymbolizer {
-  wellKnownName: 'Star';
   points: 5;
+  wellKnownName: 'Star';
   radius1?: number;
   radius2?: number;
 }
@@ -177,10 +178,10 @@ export interface StarSymbolizer extends BaseMarkSymbolizer {
  * a regular cross geometry
  */
 export interface CrossSymbolizer extends BaseMarkSymbolizer {
-  wellKnownName: 'Cross';
   points: 4;
-  radius1?: number;
   radius2: 0;
+  wellKnownName: 'Cross';
+  radius1?: number;
 }
 
 /**
@@ -188,11 +189,11 @@ export interface CrossSymbolizer extends BaseMarkSymbolizer {
  * a regular cross geometry
  */
 export interface XSymbolizer extends BaseMarkSymbolizer {
-  wellKnownName: 'X';
+  angle: 45;
   points: 4;
-  radius1?: number;
   radius2: 0;
-  angle: number;
+  wellKnownName: 'X';
+  radius1?: number;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,7 +123,8 @@ export interface BaseMarkSymbolizer extends BasePointSymbolizer {
   wellKnownName: 'Circle' | 'Square' | 'Triangle' | 'Star' | 'Cross' | 'X';
   angle?: number;
   points?: number;
-  rotation?: number;
+  radius?: number;
+  rotate?: number;
   strokeColor?: string;
   strokeOpacity?: number;
   strokeWidth?: number;
@@ -138,7 +139,6 @@ export interface CircleSymbolizer extends BaseMarkSymbolizer {
   blur?: number;
   pitchAlignment?: 'map' | 'viewport';
   pitchScale?: 'map' | 'viewport';
-  radius?: number;
 }
 
 /**
@@ -149,7 +149,6 @@ export interface SquareSymbolizer extends BaseMarkSymbolizer {
   angle: 45;
   points: 4;
   wellKnownName: 'Square';
-  radius?: number;
 }
 
 /**
@@ -159,7 +158,6 @@ export interface SquareSymbolizer extends BaseMarkSymbolizer {
 export interface TriangleSymbolizer extends BaseMarkSymbolizer {
   points: 3;
   wellKnownName: 'Triangle';
-  radius?: number;
 }
 
 /**
@@ -169,7 +167,6 @@ export interface TriangleSymbolizer extends BaseMarkSymbolizer {
 export interface StarSymbolizer extends BaseMarkSymbolizer {
   points: 5;
   wellKnownName: 'Star';
-  radius1?: number;
   radius2?: number;
 }
 
@@ -179,9 +176,8 @@ export interface StarSymbolizer extends BaseMarkSymbolizer {
  */
 export interface CrossSymbolizer extends BaseMarkSymbolizer {
   points: 4;
-  radius2: 0;
+  radius2?: 0;
   wellKnownName: 'Cross';
-  radius1?: number;
 }
 
 /**
@@ -191,9 +187,8 @@ export interface CrossSymbolizer extends BaseMarkSymbolizer {
 export interface XSymbolizer extends BaseMarkSymbolizer {
   angle: 45;
   points: 4;
-  radius2: 0;
+  radius2?: 0;
   wellKnownName: 'X';
-  radius1?: number;
 }
 
 /**

--- a/sample.ts
+++ b/sample.ts
@@ -57,7 +57,8 @@ const sampleStyle: Style = {
         max: 1000
       },
       symbolizer: [{
-        kind: 'Circle',
+        kind: 'Mark',
+        wellKnownName: 'Circle',
         visibility: false,
         radius: 5,
         spacing: 21


### PR DESCRIPTION
Definitions for WellKnownNames were added. MarkSymbolizer definition was added that consists of a single WellKnownNameSymbolizer (i.e. CircleSymbolizer, SquareSymbolizer, etc.).

PointSymbolizer can be MarkSymbolizer. CircleSymbolizer belongs to MarkSymbolizer now and is not part of SymbolizerKind anymore.

Following WellKnownNames are allowed: `Circle`, `Square`, `Triangle`, `Star`, `Cross`, `X`.