### PR TITLE
LineSymbolizer GraphicFill & GraphicStroke

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -264,6 +264,11 @@ export interface FillSymbolizer extends BaseSymbolizer {
 }
 
 /**
+ * The Types that are allowed in a graphic
+ */
+export type GraphicType = 'Mark' | 'Icon';
+
+/**
  * A LineSymbolizer describes the style representation of LINESTRING data.
  */
 export interface LineSymbolizer extends BaseSymbolizer {
@@ -273,7 +278,8 @@ export interface LineSymbolizer extends BaseSymbolizer {
   dasharray?: number[];
   gapWidth?: number;
   gradient?: any[];
-  graphicStroke?: PointSymbolizer; 
+  graphicStroke?: PointSymbolizer;
+  graphicFill?: PointSymbolizer;
   join?: 'bevel' | 'round' | 'miter';
   miterLimit?: number;
   // TODO check if offset is being used somewhere, or if perpendicularOffset and dashOffset already replace it

--- a/sample.ts
+++ b/sample.ts
@@ -21,6 +21,19 @@ const sampleStyle: Style = {
         optional: false,
         rotationAlignment: 'map',
         spacing: 21
+      }, {
+        kind: 'Line',
+        blur: 3,
+        cap: 'square',
+        join: 'round',
+        perpendicularOffset: 10,
+        width: 9,
+        graphicStroke: {
+          kind: 'Mark',
+          wellKnownName: 'Square',
+          points: 4,
+          angle: 45
+        }
       }]
     },
     {


### PR DESCRIPTION
Defined additional properties for GraphicFill and GraphicStroke. Both of type PointSymbolizer (only MarkSymbolizer and IconSymbolizer will be parsed since TextSymbolizer is its own Symbolizer in SLD specification).

Also defined `GraphicType` containing the kinds that are allowed in a Graphic.