### PR TITLE
Definition for IconSymbolizer format

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -227,6 +227,11 @@ export interface TextSymbolizer extends BasePointSymbolizer {
 }
 
 /**
+ * IconMime describes the supported mime types for an IconSymbolizer
+ */
+export type IconMime = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/svg+xml';
+
+/**
  * A FillSymbolizer describes the style representation of POINT data if styled with
  * an specific icon.
  */
@@ -234,6 +239,7 @@ export interface IconSymbolizer extends BasePointSymbolizer {
   kind: 'Icon';
   allowOverlap?: boolean;
   anchor?: 'center' | 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  format?: IconMime;
   haloBlur?: number;
   haloColor?: string;
   haloWidth?: number;

--- a/sample.ts
+++ b/sample.ts
@@ -15,6 +15,7 @@ const sampleStyle: Style = {
       },
       symbolizers: [{
         kind: 'Icon',
+        format: 'image/svg+xml',
         visibility: false,
         allowOverlap: true,
         ignorePlacement: false,


### PR DESCRIPTION
IconSymbolizer now has a property format that contains the mime-type of a specified image.

Supported mime-types are:
`image/png` `image/jpeg` `image/gif` `image/svg+xml`