### PR TITLE
Removes @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "release": "np --no-yarn && git push https://github.com/terrestris/geostyler-style.git master --tags"
   },
   "devDependencies": {
-    "@types/node": "11.9.4",
     "np": "4.0.2",
     "tslint": "5.12.1",
     "typescript": "3.3.3"


### PR DESCRIPTION
This removes `@types/node` as it was just needed for jest which was removed in #110.

@terrestris/devs please review