### PR TITLE
Add definition for RasterSymbolizer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -244,7 +244,7 @@ export interface ColorMapEntry {
 /**
  * The Types that are allowed in a ColorMap.
  */
-export type ColorMapType = 'ramp'|'intervals'|'values';
+export type ColorMapType = 'ramp' | 'intervals' | 'values';
 
 /**
  * A ColorMap defines the color values for the pixels of a raster image.

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export interface ScaleDenominator {
 /**
  * The type of the Style.
  */
-export type StyleType = 'Point' | 'Fill' | 'Line';
+export type StyleType = 'Point' | 'Fill' | 'Line' | 'Raster';
 
 /**
  * The possible Operator used for comparison Filters.

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ export interface NegationFilter extends Filter  {
 /**
  * The kind of the Symbolizer
  */
-export type SymbolizerKind = 'Fill' | 'Icon' | 'Line' | 'Text' | 'Mark';
+export type SymbolizerKind = 'Fill' | 'Icon' | 'Line' | 'Text' | 'Mark' | 'Raster';
 
 /**
  * A Symbolizer describes the style representation of geographical data.
@@ -232,9 +232,76 @@ export interface LineSymbolizer extends BaseSymbolizer {
 export type PointSymbolizer = IconSymbolizer | MarkSymbolizer | TextSymbolizer;
 
 /**
+ * A single entry for the ColorMap.
+ */
+export interface ColorMapEntry {
+  color: string;
+  quantity?: number;
+  label?: string;
+  opacity?: number;
+}
+
+/**
+ * The Types that are allowed in a ColorMap.
+ */
+export type ColorMapType = 'ramp'|'intervals'|'values';
+
+/**
+ * A ColorMap defines the color values for the pixels of a raster image.
+ */
+export interface ColorMap {
+    type: ColorMapType;
+    colorMapEntries?: ColorMapEntry[];
+    extended?: boolean;
+}
+
+/**
+ * A ContrastEnhancement defines how the contrast of image data should be enhanced.
+ */
+export interface ContrastEnhancement {
+  enhancementType?: 'normalize' | 'histogram';
+  gammaValue?: number;
+}
+
+/**
+ * A Channel defines the properties for a color channel.
+ */
+export interface Channel {
+  sourceChannelName?: string;
+  contrastEnhancement?: ContrastEnhancement;
+}
+
+/**
+ * A RGBChannel defines how dataset bands are mapped to image color channels.
+ */
+export interface RGBChannel {
+  redChannel: Channel;
+  blueChannel: Channel;
+  greenChannel: Channel;
+}
+
+/**
+ * A GrayChannel defines how a single dataset band is mapped to a grayscale channel.
+ */
+export interface GrayChannel {
+  grayChannel: Channel;
+}
+
+/**
+ * A RasterSymbolizer defines the style representation of RASTER data.
+ */
+export interface RasterSymbolizer {
+  kind: 'Raster';
+  opacity?: number;
+  colorMap?: ColorMap;
+  channelSelection?: RGBChannel | GrayChannel;
+  contrastEnhancement?: ContrastEnhancement;
+}
+
+/**
  * All operators.
  */
-export type Symbolizer = PointSymbolizer | LineSymbolizer | FillSymbolizer;
+export type Symbolizer = PointSymbolizer | LineSymbolizer | FillSymbolizer | RasterSymbolizer;
 
 /**
  * A Rule combines a specific amount of data (defined by a filter and a
@@ -279,6 +346,7 @@ export interface UnsupportedProperties {
     FillSymbolizer?: any;
     MarkSymbolizer?: any;
     IconSymbolizer?: any;
+    RasterSymbolizer?: any;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -287,6 +287,8 @@ export interface GrayChannel {
   grayChannel: Channel;
 }
 
+export type ChannelSelection = RGBChannel | GrayChannel;
+
 /**
  * A RasterSymbolizer defines the style representation of RASTER data.
  */
@@ -294,7 +296,7 @@ export interface RasterSymbolizer {
   kind: 'Raster';
   opacity?: number;
   colorMap?: ColorMap;
-  channelSelection?: RGBChannel | GrayChannel;
+  channelSelection?: ChannelSelection;
   contrastEnhancement?: ContrastEnhancement;
 }
 

--- a/rastersample.ts
+++ b/rastersample.ts
@@ -1,0 +1,39 @@
+import { Style } from 'index';
+
+const sampleRasterStyle: Style = {
+  name: 'Sample Raster Style',
+  rules: [
+    {
+      name: 'Very old Peter',
+      filter: ['&&',
+        ['==', 'name', 'Peter'],
+        ['>=', 'age', 51]
+      ],
+      scaleDenominator: {
+        min: 500,
+        max: 1000
+      },
+      symbolizers: [{
+        kind: 'Raster',
+        opacity: 1,
+        colorMap: {
+          colorMapEntries: [
+            {
+              color: '#00FFFF',
+              quantity: 100
+            }
+          ],
+          extended: false,
+          type: 'ramp'
+        },
+        channelSelection: {
+          grayChannel: {
+            sourceChannelName: '1'
+          }
+        }
+      }]
+    }
+  ]
+};
+
+export default sampleRasterStyle;

--- a/sample.ts
+++ b/sample.ts
@@ -91,6 +91,24 @@ const sampleStyle: Style = {
         graphicFill: {
           kind: 'Icon'
         }
+      }, {
+        kind: 'Raster',
+        opacity: 1,
+        colorMap: {
+          colorMapEntries: [
+            {
+              color: '#00FFFF',
+              quantity: 100
+            }
+          ],
+          extended: false,
+          type: "ramp"
+        },
+        channelSelection: {
+          grayChannel: {
+            sourceChannelName: '1'
+          }
+        }
       }]
     }
   ]

--- a/sample.ts
+++ b/sample.ts
@@ -102,7 +102,7 @@ const sampleStyle: Style = {
             }
           ],
           extended: false,
-          type: "ramp"
+          type: 'ramp'
         },
         channelSelection: {
           grayChannel: {


### PR DESCRIPTION
Adds an initial definition for a RasterSymbolizer based on SLD specification.

More specifically, defines:
- Opacity
- ColorMap
- ChannelSelection
- ContrastEnhancement