### PR TITLE
Remove constructable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -357,6 +357,11 @@ export interface UnsupportedProperties {
  */
 export interface StyleParser {
   /**
+   * The name of the Parser
+   */
+  title: string;
+
+  /**
    * Parses the inputStyle and transforms it to the GeoStyler Style
    *
    * @param inputStyle
@@ -439,13 +444,3 @@ export interface StyleParser {
   unsupportedProperties?: UnsupportedProperties;
 }
 
-export interface StyleParserConstructable extends StyleParser {
-  /**
-   * Constructor interface
-   */
-  new(): StyleParser;
-  /**
-   * The name of the Parser instance
-   */
-  title: string;
-}


### PR DESCRIPTION
# Breaking Change

With the now proper creation of definition files in the parsers (e.g. https://github.com/terrestris/geostyler-sld-parser/pull/165) it occurred that the StyleParserConstructable does not work correctly. We decided to remove it and shift the parser title to the instance.

With this change, it will not be possible to work with typed StyleParserConstructables anymore. So, gui components should now only accept styleParser instances.