### PR TITLE
Add fontStyle and fontWeight to TextSymbolizer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -162,6 +162,8 @@ export interface TextSymbolizer extends BasePointSymbolizer {
   rotationAlignment?: 'map' | 'viewport' | 'auto';
   size?: number;
   transform?: 'none' | 'uppercase' | 'lowercase';
+  fontStyle?: 'normal' | 'italic' | 'oblique';
+  fontWeight?: 'normal' | 'bold';
 }
 
 /**

--- a/sample.ts
+++ b/sample.ts
@@ -54,7 +54,9 @@ const sampleStyle: Style = {
         rotationAlignment: 'map',
         spacing: 21,
         haloColor: '#ff00aa',
-        haloWidth: 4
+        haloWidth: 4,
+        fontStyle: 'italic',
+        fontWeight: 'bold'
       }]
     },
     {


### PR DESCRIPTION
This is based on https://github.com/terrestris/geostyler-style/pull/114 and https://github.com/terrestris/geostyler-style/pull/115, which seems to be not maintained anymore.

Adding `fontStyle` and `fontWeight` properties to `TextSymbolizer`. Updated sample.ts accordingly.