### PR TITLE
Adapts multiple Properties / Symbolizers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -505,10 +505,6 @@ export interface LineSymbolizer extends BaseSymbolizer {
    */
   spacing?: number;
   /**
-   * TODO: CHECK where this property came from and if we need it
-   */
-  type?: string;
-  /**
    * The width of the Line in pixels.
    */
   width?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,17 +121,6 @@ interface BaseSymbolizer {
    */
   opacity?: number;
   /**
-   * The offset of the Symbolizer as [x, y] coordinates. Positive values indicate
-   * right and down, while negative values indicate left and up.
-   * TODO: Duplicate with offset
-   */
-  translate?: [number, number];
-  /**
-   * Property relevant for mapbox-styles.
-   * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor
-   */
-  translateAnchor?: 'map' | 'viewport';
-  /**
    * Defines whether the Symbolizer should be visibile or not.
    */
   visibility?: boolean;
@@ -149,9 +138,13 @@ export interface BasePointSymbolizer extends BaseSymbolizer {
   /**
    * The offset of the Symbolizer as [x, y] coordinates. Positive values indicate
    * right and down, while negative values indicate left and up.
-   * TODO: Duplicate with translate
    */
   offset?: [number, number];
+  /**
+   * Property relevant for mapbox-styles.
+   * Compare https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-icon-translate-anchor
+   */
+  offsetAnchor?: 'map' | 'viewport';
 }
 
 /**
@@ -339,7 +332,7 @@ export interface IconSymbolizer extends BasePointSymbolizer {
   allowOverlap?: boolean;
   /**
    * Part of the icon placed closest to the anchor. This may conflict with a set
-   * offset/translation.
+   * offset.
    */
   anchor?: 'center' | 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -272,7 +272,9 @@ export interface TextSymbolizer extends BasePointSymbolizer {
    */
   maxWidth?: number;
   /**
-   * TODO: CHECK where this property came from and if we need it
+   * Property relevant for mapbox-styles.
+   * If true, icons will display without their corresponding text when the text
+   * collides with other symbols and the icon does not.
    */
   optional?: boolean;
   /**
@@ -352,7 +354,9 @@ export interface IconSymbolizer extends BasePointSymbolizer {
    */
   keepUpright?: boolean;
   /**
-   * TODO: CHECK where this property came from and if we need it
+   * Property relevant for mapbox-styles.
+   * If true, text will display without their corresponding icons when the icon
+   * collides with other symbols and the text does not.
    */
   optional?: boolean;
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,11 +147,6 @@ export interface BasePointSymbolizer extends BaseSymbolizer {
    */
   avoidEdges?: boolean;
   /**
-   * Distance between two symbol anchors in pixels.
-   * TODO: Move to LineSymbolizer
-   */
-  spacing?: number;
-  /**
    * The offset of the Symbolizer as [x, y] coordinates. Positive values indicate
    * right and down, while negative values indicate left and up.
    * TODO: Duplicate with translate
@@ -502,6 +497,10 @@ export interface LineSymbolizer extends BaseSymbolizer {
    * Used to automatically convert round joins to miter joins for shallow angles.
    */
   roundLimit?: number;
+  /**
+   * Distance between two symbol anchors in pixels.
+   */
+  spacing?: number;
   /**
    * TODO: CHECK where this property came from and if we need it
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -117,6 +117,7 @@ interface BaseSymbolizer {
    */
   color?: string;
   /**
+   * Determines the total opacity for the Symbolizer.
    * A value between 0 and 1. 0 is none opaque and 1 is full opaque.
    */
   opacity?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -182,6 +182,11 @@ export interface MarkSymbolizer extends BasePointSymbolizer {
    */
   rotate?: number;
   /**
+   * The opacity of the fill. A value between 0 and 1.
+   * 0 is none opaque and 1 is full opaque.
+   */
+  fillOpacity?: number;
+  /**
    * The color of the stroke represented as a hex-color string.
    */
   strokeColor?: string;
@@ -410,10 +415,20 @@ export interface FillSymbolizer extends BaseSymbolizer {
    */
   antialias?: boolean;
   /**
+   * The opacity of the fill. A value between 0 and 1.
+   * 0 is none opaque and 1 is full opaque.
+   */
+  fillOpacity?: number;
+  /**
    * The outline color as a hex-color string. Matches the value of fill-color if
    * unspecified.
    */
   outlineColor?: string;
+  /**
+   * The opacity of the outline. A value between 0 and 1.
+   * 0 is none opaque and 1 is full opaque.
+   */
+  outlineOpacity?: number;
   /**
    * The outline width in pixels.
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -218,7 +218,6 @@ export interface TextSymbolizer extends BasePointSymbolizer {
   /**
    * If true, the text will be visible even if it collides with other previously
    * drawn symbols.
-   * TODO: Duplicate of ignorePlacement
    */
   allowOverlap?: boolean;
   /**
@@ -248,10 +247,6 @@ export interface TextSymbolizer extends BasePointSymbolizer {
    * Distance of halo to the font outline in pixels.
    */
   haloWidth?: number;
-  /**
-   * TODO: Duplicate of allowOverlap?
-   */
-  ignorePlacement?: boolean;
   /**
    * Text justification option to align the text.
    */
@@ -348,10 +343,6 @@ export interface IconSymbolizer extends BasePointSymbolizer {
    * Distance of halo to the font outline in pixels.
    */
   haloWidth?: number;
-  /**
-   * TODO: Duplicate of allowOverlap?
-   */
-  ignorePlacement?: boolean;
   /**
    * A path/URL to the icon image file.
    */

--- a/sample.ts
+++ b/sample.ts
@@ -17,10 +17,8 @@ const sampleStyle: Style = {
         kind: 'Icon',
         visibility: false,
         allowOverlap: true,
-        ignorePlacement: false,
         optional: false,
-        rotationAlignment: 'map',
-        spacing: 21
+        rotationAlignment: 'map'
       }, {
         kind: 'Line',
         blur: 3,
@@ -28,6 +26,7 @@ const sampleStyle: Style = {
         join: 'round',
         perpendicularOffset: 10,
         width: 9,
+        spacing: 21,
         graphicStroke: {
           kind: 'Mark',
           wellKnownName: 'Square'
@@ -49,10 +48,8 @@ const sampleStyle: Style = {
         visibility: false,
         allowOverlap: true,
         letterSpacing: 12,
-        ignorePlacement: false,
         optional: false,
         rotationAlignment: 'map',
-        spacing: 21,
         haloColor: '#ff00aa',
         haloWidth: 4,
         fontStyle: 'italic',
@@ -73,8 +70,7 @@ const sampleStyle: Style = {
         kind: 'Mark',
         wellKnownName: 'Circle',
         visibility: false,
-        radius: 5,
-        spacing: 21
+        radius: 5
       }]
     },
     {


### PR DESCRIPTION
## :exclamation:  Breaking Changes :exclamation: 

This adds some bigger changes to the `geostyler-style` and adapts some properties:

- ca8207c Removes `type` property from LineSymbolizer. Seems to be a copy & paste thing from the first days of GeoStyler.
- e330cae Adapts docs for `optional`.
- 57a2e63 Removes `ignorePlacement` as it is (more or less) a duplicate of `allowOverlap`.
- 58fff46 Removes `translate` as it was a duplicate of `offset` and moves `BaseSymbolizer.translateAnchor` to `BasePointSymbolizer.offsetAnchor`.
- 9a88908 Adds `fillOpacity` to `MarkerSymbolizer` and `fillOpacity` and `outlineOpacity` to `FillSymbolizer` as the general `opacity` property on the `BasePointSymbolizer` is not precise enough.
- 5d14249 Moves `spacing` to `LineSymbolizer`.
